### PR TITLE
refactor: make deploy cmd intuitive to use

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,11 +108,10 @@ program
   .command('deploy')
   .description('Deploy contracts to different networks, only supports devnet and testnet')
   .option('--network <network>', 'Specify the network to deploy to', 'devnet')
-  .option('--target <target>', 'Specify the script binaries file/folder path to deploy')
-  .option('--config <config>', 'Specify the offckb.config.ts file path for deployment', undefined)
+  .option('--target <target>', 'Specify the script binaries file/folder path to deploy', './')
+  .option('-a, --artifacts <artifacts>', 'Specify the artifacts save path for the deployment', './deployment')
   .option('-t, --type-id', 'Specify if use upgradable type id to deploy the script')
   .option('--privkey <privkey>', 'Specify the private key to deploy scripts')
-  .option('-r, --proxy-rpc', 'Use Proxy RPC to connect to blockchain')
   .action((options: DeployOptions) => deploy(options));
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,7 +109,7 @@ program
   .description('Deploy contracts to different networks, only supports devnet and testnet')
   .option('--network <network>', 'Specify the network to deploy to', 'devnet')
   .option('--target <target>', 'Specify the script binaries file/folder path to deploy', './')
-  .option('-a, --artifacts <artifacts>', 'Specify the artifacts save path for the deployment', './deployment')
+  .option('-o, --output <output>', 'Specify the output folder path for the deployment record files', './deployment')
   .option('-t, --type-id', 'Specify if use upgradable type id to deploy the script')
   .option('--privkey <privkey>', 'Specify the private key to deploy scripts')
   .action((options: DeployOptions) => deploy(options));

--- a/src/cmd/deploy.ts
+++ b/src/cmd/deploy.ts
@@ -9,13 +9,13 @@ import { confirm } from '@inquirer/prompts';
 
 export interface DeployOptions extends NetworkOption {
   target?: string;
-  artifacts?: string;
+  output?: string;
   privkey?: string | null;
   typeId?: boolean;
 }
 
 export async function deploy(
-  opt: DeployOptions = { network: Network.devnet, typeId: false, target: './', artifacts: './deployment' },
+  opt: DeployOptions = { network: Network.devnet, typeId: false, target: './', output: './deployment' },
 ) {
   const network = opt.network as Network;
   validateNetworkOpt(network);
@@ -27,7 +27,7 @@ export async function deploy(
   const privateKey = opt.privkey || deployerAccount.privkey;
   const enableTypeId = opt.typeId ?? false;
   const targetFolder = opt.target!;
-  const artifactsFolder = opt.artifacts!;
+  const outputFolder = opt.output!;
 
   const binFilesOrFolder = isAbsolutePath(targetFolder) ? targetFolder : path.resolve(process.cwd(), targetFolder);
   let binPaths = getBinaryFilesFromPath(binFilesOrFolder);
@@ -47,7 +47,7 @@ export async function deploy(
   for (const binPath of binPaths) {
     console.log(`- ${binPath}`);
   }
-  console.log(`\nThe deployment will be saved to ${artifactsFolder}`);
+  console.log(`\nThe deployment will be saved to ${outputFolder}`);
   console.log(`\nThe network is: ${network}`);
 
   const res = await confirm({
@@ -62,5 +62,5 @@ export async function deploy(
   const results = await deployBinaries(binPaths, privateKey, enableTypeId, ckb);
 
   // record the deployed contract infos
-  saveArtifacts(artifactsFolder, results, network);
+  saveArtifacts(outputFolder, results, network);
 }

--- a/src/cmd/deploy.ts
+++ b/src/cmd/deploy.ts
@@ -3,66 +3,37 @@ import path from 'path';
 import { deployerAccount } from '../cfg/account';
 import { isAbsolutePath, getBinaryFilesFromPath, getBinaryFileSizeInBytes } from '../util/fs';
 import { validateNetworkOpt } from '../util/validator';
-import { deployBinaries, getToDeployBinsPath, recordDeployResult } from '../deploy';
+import { deployBinaries, saveArtifacts } from '../deploy';
 import { CKB } from '../sdk/ckb';
-import fs from 'fs';
+import { confirm } from '@inquirer/prompts';
 
 export interface DeployOptions extends NetworkOption {
   target?: string;
-  config?: string;
+  artifacts?: string;
   privkey?: string | null;
   typeId?: boolean;
 }
 
-export async function deploy(opt: DeployOptions = { network: Network.devnet, typeId: false, target: undefined }) {
+export async function deploy(
+  opt: DeployOptions = { network: Network.devnet, typeId: false, target: './', artifacts: './deployment' },
+) {
   const network = opt.network as Network;
   validateNetworkOpt(network);
 
-  const ckb = new CKB({ network });
+  // todo: enable proxy rpc for testnet and mainnet
+  const ckb = new CKB({ network, isEnableProxyRpc: network === Network.devnet });
 
   // we use deployerAccount to deploy contract by default
   const privateKey = opt.privkey || deployerAccount.privkey;
   const enableTypeId = opt.typeId ?? false;
-  const configPath = opt.config;
-  const targetFolder = opt.target;
-  if (targetFolder) {
-    const binFilesOrFolder = isAbsolutePath(targetFolder) ? targetFolder : path.resolve(process.cwd(), targetFolder);
-    let binPaths = getBinaryFilesFromPath(binFilesOrFolder);
+  const targetFolder = opt.target!;
+  const artifactsFolder = opt.artifacts!;
 
-    // ignore the binary file which is too large(> 500kb) to upload on chain
-    binPaths = binPaths.filter((binPath) => {
-      const size = getBinaryFileSizeInBytes(binPath);
-      if (size > 500 * 1024) {
-        console.warn(
-          `[warning]: ignore deploying the binary file ${binPath} since its size is too large: ${size} bytes`,
-        );
-        return false;
-      }
-      return true;
-    });
-
-    const results = await deployBinaries(binPaths, privateKey, enableTypeId, ckb);
-
-    // record the deployed contract infos
-    recordDeployResult(results, network); // we don't update my-scripts.json since we don't know where the file is
-    return;
-  }
-
-  // read contract bin folder
-  const userOffCKBConfigPath = configPath
-    ? isAbsolutePath(configPath)
-      ? configPath
-      : path.resolve(process.cwd(), configPath)
-    : path.resolve(process.cwd(), 'offckb.config.ts');
-  if (!fs.existsSync(userOffCKBConfigPath)) {
-    throw new Error(
-      `config file not exits: ${userOffCKBConfigPath}, tips: use --config to specific the offckb.config.ts file`,
-    );
-  }
-  let bins = getToDeployBinsPath(userOffCKBConfigPath);
+  const binFilesOrFolder = isAbsolutePath(targetFolder) ? targetFolder : path.resolve(process.cwd(), targetFolder);
+  let binPaths = getBinaryFilesFromPath(binFilesOrFolder);
 
   // ignore the binary file which is too large(> 500kb) to upload on chain
-  bins = bins.filter((binPath) => {
+  binPaths = binPaths.filter((binPath) => {
     const size = getBinaryFileSizeInBytes(binPath);
     if (size > 500 * 1024) {
       console.warn(`[warning]: ignore deploying the binary file ${binPath} since its size is too large: ${size} bytes`);
@@ -71,8 +42,25 @@ export async function deploy(opt: DeployOptions = { network: Network.devnet, typ
     return true;
   });
 
-  const results = await deployBinaries(bins, privateKey, enableTypeId, ckb);
+  // ask user to confirm the deployment
+  console.log('You are about to deploy the following contracts:');
+  for (const binPath of binPaths) {
+    console.log(`- ${binPath}`);
+  }
+  console.log(`\nThe deployment will be saved to ${artifactsFolder}`);
+  console.log(`\nThe network is: ${network}`);
+
+  const res = await confirm({
+    message: 'Are you sure you want to deploy these contracts?',
+  });
+
+  if (!res) {
+    console.log('Deployment cancelled.');
+    return;
+  }
+
+  const results = await deployBinaries(binPaths, privateKey, enableTypeId, ckb);
 
   // record the deployed contract infos
-  recordDeployResult(results, network, userOffCKBConfigPath);
+  saveArtifacts(artifactsFolder, results, network);
 }

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -65,9 +65,9 @@ export async function saveArtifacts(artifactsPath: string, results: DeployedInte
     deployedScriptsInfo[name] = scriptsInfo;
   }
 
-  const scriptInfoFilePath = path.join(artifactsPath, 'my-scripts.json');
+  const scriptInfoFilePath = path.join(artifactsPath, 'scripts.json');
   generateScriptInfoJsonFile(network, deployedScriptsInfo, scriptInfoFilePath);
-  console.log(`Script info json file ${scriptInfoFilePath} generated successfully.`);
+  console.log(`Script info file ${scriptInfoFilePath} generated successfully.`);
 }
 
 export async function recordDeployResult(

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -1,5 +1,11 @@
-import { DeploymentOptions, generateDeploymentToml } from '../deploy/toml';
-import { DeploymentRecipe, generateDeploymentMigrationFile, Migration } from '../deploy/migration';
+import { DeploymentOptions, generateDeploymentToml, generateDeploymentTomlInPath } from '../deploy/toml';
+import {
+  DeploymentRecipe,
+  generateDeploymentMigrationFile,
+  generateDeploymentMigrationFileInPath,
+  getFormattedMigrationDate,
+  Migration,
+} from '../deploy/migration';
 import { genMyScriptsJsonFile } from '../scripts/gen';
 import { OffCKBConfigFile } from '../template/offckb-config';
 import { readFileToUint8Array, isAbsolutePath, getBinaryFilesFromPath } from '../util/fs';
@@ -9,6 +15,9 @@ import { Network } from '../type/base';
 import { CKB } from '../sdk/ckb';
 import { HexString } from '../type/base';
 import { ccc } from '@ckb-ccc/core';
+import { MyScriptsRecord } from '../scripts/type';
+import { getScriptInfoFrom } from '../scripts/util';
+import { generateScriptInfoJsonFile } from './script';
 
 export type DeployBinaryReturnType = ReturnType<typeof deployBinary>;
 export type UnwrapPromise<T> = T extends Promise<infer U> ? U : T;
@@ -30,6 +39,35 @@ export function getToDeployBinsPath(userOffCKBConfigPath: string) {
     console.log('contractBinFolder value not found in offckb.config.ts');
     return [];
   }
+}
+
+export async function saveArtifacts(artifactsPath: string, results: DeployedInterfaceType[], network: Network) {
+  if (results.length === 0) {
+    return console.log('No artifacts to save.');
+  }
+  if (!fs.existsSync(artifactsPath)) {
+    fs.mkdirSync(artifactsPath, { recursive: true });
+  }
+  const deployedScriptsInfo: MyScriptsRecord = {};
+  for (const result of results) {
+    console.log(`Saving artifacts for ${result.deploymentOptions.name}...`);
+    const tomlPath = path.join(artifactsPath, network, result.deploymentOptions.name, 'deployment.toml');
+    generateDeploymentTomlInPath(result.deploymentOptions, tomlPath);
+    const migrationPath = path.join(
+      artifactsPath,
+      network,
+      result.deploymentOptions.name,
+      'migrations',
+      `${getFormattedMigrationDate()}.json`,
+    );
+    generateDeploymentMigrationFileInPath(result.deploymentRecipe, migrationPath);
+    const { name, scriptsInfo } = getScriptInfoFrom(result.deploymentRecipe);
+    deployedScriptsInfo[name] = scriptsInfo;
+  }
+
+  const scriptInfoFilePath = path.join(artifactsPath, 'my-scripts.json');
+  generateScriptInfoJsonFile(network, deployedScriptsInfo, scriptInfoFilePath);
+  console.log(`Script info json file ${scriptInfoFilePath} generated successfully.`);
 }
 
 export async function recordDeployResult(

--- a/src/deploy/migration.ts
+++ b/src/deploy/migration.ts
@@ -72,22 +72,24 @@ export class Migration {
   }
 }
 
+export function generateDeploymentMigrationFileInPath(deploymentRecipe: DeploymentRecipe, outputFilePath: string) {
+  const cellRecipes = deploymentRecipe.cellRecipes;
+  const depGroupRecipes = deploymentRecipe.depGroupRecipes;
+  const jsonString = JSON.stringify(deploymentRecipeToJson({ cellRecipes, depGroupRecipes }), null, 2);
+  if (!fs.existsSync(dirname(outputFilePath))) {
+    fs.mkdirSync(dirname(outputFilePath), { recursive: true });
+  }
+  fs.writeFileSync(outputFilePath, jsonString);
+  console.log(`Migration json file ${outputFilePath} generated successfully.`);
+}
+
 export function generateDeploymentMigrationFile(
   name: string,
   deploymentRecipe: DeploymentRecipe,
   network = Network.devnet,
 ) {
-  const cellRecipes = deploymentRecipe.cellRecipes;
-  const depGroupRecipes = deploymentRecipe.depGroupRecipes;
-  const jsonString = JSON.stringify(deploymentRecipeToJson({ cellRecipes, depGroupRecipes }), null, 2);
   const outputFilePath: string = `${getContractsPath(network)}/${name}/migrations/${getFormattedMigrationDate()}.json`;
-  if (outputFilePath) {
-    if (!fs.existsSync(dirname(outputFilePath))) {
-      fs.mkdirSync(dirname(outputFilePath), { recursive: true });
-    }
-    fs.writeFileSync(outputFilePath, jsonString);
-    console.log(`${name} migration json file ${outputFilePath} generated successfully.`);
-  }
+  return generateDeploymentMigrationFileInPath(deploymentRecipe, outputFilePath);
 }
 
 export function readDeploymentMigrationFile(filePath: string): DeploymentRecipe {

--- a/src/deploy/script.ts
+++ b/src/deploy/script.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import { MyScriptsRecord, NetworkMyScripts } from '../scripts/type';
+import { Network } from '../type/base';
+import fs from 'fs';
+
+export function generateScriptInfoJsonFile(network: Network, myScriptsRecord: MyScriptsRecord, outputFilePath: string) {
+  let scripts: NetworkMyScripts = {
+    devnet: {},
+    testnet: {},
+    mainnet: {},
+  };
+
+  // read the output file first if it exists
+  if (fs.existsSync(outputFilePath)) {
+    const existingScripts: NetworkMyScripts = JSON.parse(fs.readFileSync(outputFilePath, 'utf8')) as NetworkMyScripts;
+    existingScripts[network] = myScriptsRecord;
+    scripts = existingScripts;
+  } else {
+    scripts[network] = myScriptsRecord;
+  }
+
+  fs.mkdirSync(path.dirname(outputFilePath), { recursive: true });
+  fs.writeFileSync(outputFilePath, JSON.stringify(scripts, null, 2));
+}

--- a/src/deploy/toml.ts
+++ b/src/deploy/toml.ts
@@ -32,7 +32,7 @@ export interface DeploymentToml {
   };
 }
 
-export function generateDeploymentToml(options: DeploymentOptions, network: Network) {
+export function generateDeploymentTomlInPath(options: DeploymentOptions, outputFilePath: string) {
   const data: DeploymentToml = {
     cells: [
       {
@@ -51,7 +51,6 @@ export function generateDeploymentToml(options: DeploymentOptions, network: Netw
   };
 
   const tomlString = toml.stringify(data as unknown as JsonMap);
-  const outputFilePath: string = `${getContractsPath(network)}/${options.name}/deployment.toml`;
   if (outputFilePath) {
     if (!fs.existsSync(dirname(outputFilePath))) {
       fs.mkdirSync(dirname(outputFilePath), { recursive: true });
@@ -61,8 +60,12 @@ export function generateDeploymentToml(options: DeploymentOptions, network: Netw
   }
 }
 
-export function readDeploymentToml(scriptName: string, network: Network) {
-  const filePath = `${getContractsPath(network)}/${scriptName}/deployment.toml`;
+export function generateDeploymentToml(options: DeploymentOptions, network: Network) {
+  const outputFilePath: string = `${getContractsPath(network)}/${options.name}/deployment.toml`;
+  return generateDeploymentTomlInPath(options, outputFilePath);
+}
+
+export function readDeploymentTomlInPath(filePath: string) {
   const file = fs.readFileSync(filePath, 'utf-8');
   const data = toml.parse(file) as unknown as DeploymentToml;
   return {
@@ -81,4 +84,9 @@ export function readDeploymentToml(scriptName: string, network: Network) {
       hashType: data.lock.hash_type as string,
     },
   };
+}
+
+export function readDeploymentToml(scriptName: string, network: Network) {
+  const filePath = `${getContractsPath(network)}/${scriptName}/deployment.toml`;
+  return readDeploymentTomlInPath(filePath);
 }

--- a/src/scripts/util.ts
+++ b/src/scripts/util.ts
@@ -1,9 +1,84 @@
 import * as fs from 'fs';
 import { getContractsPath } from '../deploy/util';
-import { getMigrationFolderPath, getNewestMigrationFile, readDeploymentMigrationFile } from '../deploy/migration';
-import { MyScriptsRecord } from '../scripts/type';
+import {
+  DeploymentRecipe,
+  getMigrationFolderPath,
+  getNewestMigrationFile,
+  readDeploymentMigrationFile,
+} from '../deploy/migration';
+import { MyScriptsRecord, ScriptInfo } from '../scripts/type';
 import { getSubfolders } from '../util/fs';
 import { Network } from '../type/base';
+import path from 'path';
+
+export function readDeployedScriptInfoFrom(contractDeploymentFolderPath: string) {
+  const deployedScriptsInfo: MyScriptsRecord = {};
+
+  // Read all files in the folder
+  if (!fs.existsSync(contractDeploymentFolderPath)) {
+    return deployedScriptsInfo;
+  }
+
+  const migrationFolderPath = path.resolve(contractDeploymentFolderPath, 'migrations');
+  if (!fs.existsSync(migrationFolderPath)) {
+    console.log(`No migrations folder found in ${migrationFolderPath}`);
+    return deployedScriptsInfo;
+  }
+
+  const newestFilePath = getNewestMigrationFile(migrationFolderPath);
+  if (!newestFilePath) {
+    console.log(`No migration file found in ${migrationFolderPath}`);
+    return deployedScriptsInfo;
+  }
+
+  try {
+    // Read the file content
+    const recipe = readDeploymentMigrationFile(newestFilePath);
+    const { name, scriptsInfo } = getScriptInfoFrom(recipe);
+    deployedScriptsInfo[name] = scriptsInfo;
+  } catch (error) {
+    console.error(`Error reading or parsing file '${newestFilePath}':`, error);
+  }
+
+  return deployedScriptsInfo;
+}
+
+export function getScriptInfoFrom(recipe: DeploymentRecipe) {
+  // todo: handle multiple cell recipes?
+  const firstCell = recipe.cellRecipes[0];
+  const isDepCode = recipe.depGroupRecipes.length > 0;
+  const scriptsInfo: ScriptInfo = {
+    codeHash: (firstCell.typeId ? firstCell.typeId : firstCell.dataHash) as `0x${string}`,
+    hashType: firstCell.typeId ? 'type' : 'data1',
+    cellDeps: !isDepCode
+      ? [
+          {
+            cellDep: {
+              outPoint: {
+                txHash: firstCell.txHash as `0x${string}`,
+                index: +firstCell.index,
+              },
+              depType: 'code',
+            },
+          },
+        ]
+      : recipe.depGroupRecipes.map((depGroupRecipe) => {
+          return {
+            cellDep: {
+              outPoint: {
+                txHash: depGroupRecipe.txHash as `0x${string}`,
+                index: +depGroupRecipe.index,
+              },
+              depType: 'depGroup',
+            },
+          };
+        }),
+  };
+  return {
+    name: firstCell.name,
+    scriptsInfo,
+  };
+}
 
 export function readUserDeployedScriptsInfo(network: Network) {
   const deployedScriptsInfo: MyScriptsRecord = {};


### PR DESCRIPTION
- remove the deps of offckb.config.ts file, make it intuitive to use
- record the deployment info in the current workspace, instead of the root space in offckb